### PR TITLE
CreateTestLogger extension method

### DIFF
--- a/src/Serilog.Sinks.XUnit/TestOutputHelperExtensions.cs
+++ b/src/Serilog.Sinks.XUnit/TestOutputHelperExtensions.cs
@@ -1,0 +1,72 @@
+﻿namespace Serilog
+{
+    using System;
+    using Serilog.Core;
+    using Serilog.Events;
+    using Serilog.Formatting;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// Provides extension methods that create Serilog loggers
+    /// directly from <see cref="ITestOutputHelper"/> objects.
+    /// </summary>
+    public static class TestOutputHelperExtensions
+    {
+        /// <summary>
+        /// Initializes a new Serilog logger that writes to xunit's <paramref name="testOutputHelper"/>.
+        /// </summary>
+        /// <param name="testOutputHelper">The <see cref="ITestOutputHelper"/> that will be written to.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum level for
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="outputTemplate">A message template describing the format used to write to the sink.
+        /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
+        /// <returns>The Serilog logger that logs to <paramref name="testOutputHelper"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="testOutputHelper"/> is null.</exception>
+        public static Logger CreateTestLogger(
+            this ITestOutputHelper testOutputHelper,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = TestOutputLoggerConfigurationExtensions.DefaultConsoleOutputTemplate,
+            IFormatProvider formatProvider = null,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            return new LoggerConfiguration()
+                  .WriteTo.TestOutput(
+                       testOutputHelper,
+                       restrictedToMinimumLevel,
+                       outputTemplate,
+                       formatProvider,
+                       levelSwitch)
+                  .CreateLogger();
+        }
+
+        /// <summary>
+        /// Initializes a new Serilog logger that writes to xunit's <paramref name="testOutputHelper"/>.
+        /// </summary>
+        /// <param name="testOutputHelper">The <see cref="ITestOutputHelper"/> that will be written to.</param>
+        /// <param name="formatter">Controls the rendering of log events into text, for example to log JSON. To
+        /// control plain text formatting, use the overload that accepts an output template.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum level for
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
+        /// <returns>The Serilog logger that logs to <paramref name="testOutputHelper"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="testOutputHelper"/>
+        /// or <paramref name="formatter"/> is null.</exception>
+        public static Logger CreateTestLogger(
+            this ITestOutputHelper testOutputHelper,
+            ITextFormatter formatter,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            return new LoggerConfiguration()
+                  .WriteTo.TestOutput(
+                       testOutputHelper,
+                       formatter,
+                       restrictedToMinimumLevel,
+                       levelSwitch)
+                  .CreateLogger();
+        }
+    }
+}

--- a/src/Serilog.Sinks.XUnit/XUnitLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.XUnit/XUnitLoggerConfigurationExtensions.cs
@@ -14,7 +14,7 @@ namespace Serilog
     /// </summary>
     public static class TestOutputLoggerConfigurationExtensions
     {
-        const string _defaultConsoleOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level}] {Message}{NewLine}{Exception}";
+        internal const string DefaultConsoleOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level}] {Message}{NewLine}{Exception}";
 
         /// <summary>
         /// Writes log events to <see cref="ITestOutputHelper"/>.
@@ -32,7 +32,7 @@ namespace Serilog
             this LoggerSinkConfiguration sinkConfiguration,
             ITestOutputHelper testOutputHelper,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            string outputTemplate = _defaultConsoleOutputTemplate,
+            string outputTemplate = DefaultConsoleOutputTemplate,
             IFormatProvider formatProvider = null,
             LoggingLevelSwitch levelSwitch = null)
         {
@@ -73,6 +73,6 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(formatter));
 
             return sinkConfiguration.Sink(new TestOutputSink(testOutputHelper, formatter), restrictedToMinimumLevel, levelSwitch);
-        }
+        }  
     }
 }

--- a/test/Serilog.Sinks.XUnit.Tests/TestOutputHelperExtensionsTests.cs
+++ b/test/Serilog.Sinks.XUnit.Tests/TestOutputHelperExtensionsTests.cs
@@ -1,0 +1,106 @@
+﻿namespace Serilog.Sinks.XUnit.Tests
+{
+    using FluentAssertions;
+    using NSubstitute;
+    using Serilog.Events;
+    using Serilog.Core;
+    using Serilog.Formatting;
+    using System;
+    using System.IO;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public static class TestOutputHelperExtensionsTests
+    {
+        [Fact]
+        public static void CreateTestLogger_WithDefaultParameters()
+        {
+            var outputMock = Substitute.For<ITestOutputHelper>();
+            var logger = outputMock.CreateTestLogger();
+
+            const string message = "This is a test message";
+            logger.Information(message);
+
+            outputMock.Received(1).WriteLine(Arg.Is<string>(text => text.Contains($"[Information] {message}")));
+        }
+
+        [Fact]
+        public static void CreateTestLogger_WithCustomMessageTemplate()
+        {
+            var outputMock = Substitute.For<ITestOutputHelper>();
+            var logger = outputMock.CreateTestLogger(outputTemplate: "Game of Thrones {Level}: {Message}");
+
+            const string message = "That's what I do. I drink and I know things.";
+            logger.Warning(message);
+
+            outputMock.Received(1).WriteLine(Arg.Is<string>(text => text.Equals($"Game of Thrones Warning: {message}")));
+        }
+
+        [Fact]
+        public static void CreateTestLogger_WithCustomMinimumLogLevel()
+        {
+            var outputMock = Substitute.For<ITestOutputHelper>();
+            var logger = outputMock.CreateTestLogger(LogEventLevel.Error);
+
+            const string message = "Foo";
+            logger.Debug(message);
+            logger.Information(message);
+            logger.Warning(message);
+            
+            outputMock.DidNotReceive().WriteLine(Arg.Any<string>());
+        }
+
+        [Fact]
+        public static void CreateTestLogger_WithCustomSwitch()
+        {
+            var outputMock = Substitute.For<ITestOutputHelper>();
+            var levelSwitch = new LoggingLevelSwitch(LogEventLevel.Warning);
+            var logger = outputMock.CreateTestLogger(levelSwitch: levelSwitch);
+
+            const string message = "Bar";
+            logger.Verbose(message);
+            logger.Debug(message);
+            logger.Information(message);
+            outputMock.DidNotReceive().WriteLine(Arg.Any<string>());
+
+            levelSwitch.MinimumLevel = LogEventLevel.Information;
+
+            logger.Information(message);
+
+            outputMock.Received(1).WriteLine(Arg.Is<string>(text => text.Contains(message)));
+        }
+
+        [Fact]
+        public static void CreateTestLogger_WithCustomTextFormatter()
+        {
+            var outputMock = Substitute.For<ITestOutputHelper>();
+            var textFormatter = Substitute.For<ITextFormatter>();
+            var logger = outputMock.CreateTestLogger(textFormatter);
+
+            const string message = "Baz";
+            logger.Error(message);
+            
+            textFormatter.Received(1).Format(
+                Arg.Is<LogEvent>(logEvent => logEvent.Level == LogEventLevel.Error && logEvent.MessageTemplate.Text == message),
+                Arg.Any<StringWriter>());
+        }
+
+        [Fact]
+        public static void CreateTestLogger_ShouldThrowIfTestOutputHelperIsNull()
+        {
+            Action act = () => default(ITestOutputHelper).CreateTestLogger();
+
+            act.Should().Throw<ArgumentNullException>()
+               .And.ParamName.Should().Be("testOutputHelper");
+        }
+
+        [Fact]
+        public static void CreateTestLogger_ShouldThrowIfFormatterIsNull()
+        {
+            Action act = () => Substitute.For<ITestOutputHelper>().CreateTestLogger(default(ITextFormatter));
+
+            act.Should().Throw<ArgumentNullException>()
+               .And.ParamName.Should().Be("formatter");
+        }
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/trbenning/serilog-sinks-xunit/issues/7, here is the pull request for the `CreateTestLogger` extension methods.

As requested, I created a new class `TestOutputHelperExtensions` and corresponding tests in `TestOutputHelperExtensionsTests`. I also touched `TestOutputLoggerConfigurationExtensions` to reuse the `DefaultConsoleOutputTemplate` (I made this constant internal) - you might want to adjust this if this isn't to your liking.

Happy holidays!