### PR TITLE
Trim extra newlines

### DIFF
--- a/src/Serilog.Sinks.XUnit/Sinks/XUnit/TestOutputSink.cs
+++ b/src/Serilog.Sinks.XUnit/Sinks/XUnit/TestOutputSink.cs
@@ -37,7 +37,7 @@ namespace Serilog.Sinks.XUnit
             
             var renderSpace = new StringWriter();
             _textFormatter.Format(logEvent, renderSpace);
-            _testOutputHelper.WriteLine(renderSpace.ToString());
+            _testOutputHelper.WriteLine(renderSpace.ToString().Trim());
         }
     }
 }

--- a/test/Serilog.Sinks.XUnit.Tests/TestOutputHelperExtensionsTests.cs
+++ b/test/Serilog.Sinks.XUnit.Tests/TestOutputHelperExtensionsTests.cs
@@ -37,6 +37,18 @@
         }
 
         [Fact]
+        public static void CreateTestLogger_WithCustomMessageTemplateWithExtraNewline()
+        {
+            var outputMock = Substitute.For<ITestOutputHelper>();
+            var logger = outputMock.CreateTestLogger(outputTemplate: "Game of Thrones {Level}: {Message}{NewLine}{Exception}");
+
+            const string message = "That's what I do. I drink and I know things.";
+            logger.Warning(message);
+
+            outputMock.Received(1).WriteLine(Arg.Is<string>(text => text.Equals($"Game of Thrones Warning: {message}")));
+        }
+
+        [Fact]
         public static void CreateTestLogger_WithCustomMinimumLogLevel()
         {
             var outputMock = Substitute.For<ITestOutputHelper>();


### PR DESCRIPTION
Using the output template
`{Timestamp:HH:mm:ss.fff} {Logger} [{Level:u3}] {Message}{NewLine}{Exception}`,
a double newline is rendered when there is no exception: one from `{NewLine}` and one from `_testOutputHelper.WriteLine()`.

This PR removes the extra newline.

Related issue: https://github.com/serilog/serilog-sinks-debug/issues/3