### PR TITLE
Replace broken "dotnet push" command with "nuget push"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,11 +60,11 @@ steps:
     verbosityPack: $(verbosity)
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
-- task: DotNetCoreCLI@2
-  displayName: 'Publish NuGet Packages'
+- task: NuGetCommand@2
   inputs:
     command: 'push'
     packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
     nuGetFeedType: 'external'
     publishFeedCredentials: 'NuGet'
+    verbosityPush: $(verbosity)
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))


### PR DESCRIPTION
dotnet push doesn't support encrypted keys