### PR TITLE
Update dependencies

### DIFF
--- a/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
+++ b/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
@@ -9,7 +9,7 @@
     <PackageTags>logging Serilog xUnit output ITestOutputHelper</PackageTags>
     <Copyright>Copyright © 2017 Todd Benning</Copyright>
     <Authors>Todd Benning</Authors>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
@@ -26,10 +26,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
+++ b/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With xunit 2.4.2, it causes an issue to have xunit.core directly referenced in a test library which should not be considered as testable (only helpers method)
We had the issue as we reference Serilog.Sinks.Xunit, which reference xunit.core
The correct usage as stated here https://xunit.net/docs/nuget-packages is to reference the extensibility packages.

This PR also includes other reference updates.