### PR TITLE
Added net8.0 and net9.0 target framework support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,13 @@ variables:
   verbosity: 'Normal'
 
 steps:
+- task: UseDotNet@2
+  displayName: 'Install .NET SDK 8.x'
+  inputs:
+    packageType: 'sdk'
+    version: '8.x.x'
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
 - task: DotNetCoreCLI@2
   displayName: 'Restore Dependencies'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,10 +23,10 @@ variables:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Install .NET SDK 8.x'
+  displayName: 'Install .NET SDK 9.x'
   inputs:
     packageType: 'sdk'
-    version: '8.x'
+    version: '9.x'
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,12 @@ variables:
 
 steps:
 - task: UseDotNet@2
+  displayName: 'Install .NET SDK 6.x'
+  inputs:
+    packageType: 'sdk'
+    version: '6.x'
+
+- task: UseDotNet@2
   displayName: 'Install .NET SDK 9.x'
   inputs:
     packageType: 'sdk'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,12 @@ steps:
     version: '6.x'
 
 - task: UseDotNet@2
+  displayName: 'Install .NET SDK 8.x'
+  inputs:
+    packageType: 'sdk'
+    version: '8.x'
+
+- task: UseDotNet@2
   displayName: 'Install .NET SDK 9.x'
   inputs:
     packageType: 'sdk'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,12 @@ variables:
 
 steps:
 - task: UseDotNet@2
+  displayName: 'Install .NET Core SDK 3.1.x'
+  inputs:
+    packageType: 'sdk'
+    version: '3.1.x'
+
+- task: UseDotNet@2
   displayName: 'Install .NET SDK 6.x'
   inputs:
     packageType: 'sdk'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ steps:
   displayName: 'Install .NET SDK 8.x'
   inputs:
     packageType: 'sdk'
-    version: '8.x.x'
+    version: '8.x'
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: DotNetCoreCLI@2

--- a/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
+++ b/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
@@ -26,11 +26,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Serilog" Version="4.1.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.9.2" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.9.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
+++ b/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
@@ -9,7 +9,7 @@
     <PackageTags>logging Serilog xUnit output ITestOutputHelper</PackageTags>
     <Copyright>Copyright © 2017 Todd Benning</Copyright>
     <Authors>Todd Benning</Authors>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
+++ b/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
@@ -34,7 +34,6 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="4.1.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.2" />

--- a/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
+++ b/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
@@ -9,7 +9,7 @@
     <PackageTags>logging Serilog xUnit output ITestOutputHelper</PackageTags>
     <Copyright>Copyright © 2017 Todd Benning</Copyright>
     <Authors>Todd Benning</Authors>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
+++ b/src/Serilog.Sinks.XUnit/Serilog.Sinks.XUnit.csproj
@@ -25,12 +25,21 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="4.1.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.2" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.9.2" />
   </ItemGroup>
+
 
 </Project>

--- a/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
+++ b/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
+++ b/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
@@ -7,7 +7,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -16,6 +16,14 @@
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
+++ b/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
@@ -7,6 +7,14 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
@@ -16,14 +24,6 @@
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
+++ b/test/Serilog.Sinks.XUnit.Tests/Serilog.Sinks.XUnit.Tests.csproj
@@ -1,18 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some of the referenced packages contain high vulnerabilities and basically all of the target frameworks are out of support by Microsoft at this point. This PR attempts to upgrade everything to support `net8.0` and `net9.0`.